### PR TITLE
Update: Change mremove -> remove for PyPsa>=1.1.2

### DIFF
--- a/chronix2grid/generation/_dispatch/_PypsaDispatchBackend/_EDispatch_L2RPN2020/utils.py
+++ b/chronix2grid/generation/_dispatch/_PypsaDispatchBackend/_EDispatch_L2RPN2020/utils.py
@@ -247,7 +247,7 @@ def preprocess_net(net, every_min, input_data_resolution=5):
     """      
     # Remove all loads modelled in PyPSA
     # and create one single agg_load.
-    net.mremove('Load', names=net.loads.index)  
+    net.remove('Load', name=net.loads.index)  
     net.add('Load', name='agg_load', bus=net.buses.index.tolist()[0])
     # Adapt ramps according to the skipping time
     # configured to run the OPF. 


### PR DESCRIPTION
Minor change to not use deprecated mremove() method in PypsaDispatcher.

Partially addresses issue #88
